### PR TITLE
solve UnicodeEncodeError while using Chinese wiki dump to build dictionary with min-entity-count 0

### DIFF
--- a/wikipedia2vec/dictionary.pyx
+++ b/wikipedia2vec/dictionary.pyx
@@ -225,14 +225,13 @@ cdef class Dictionary:
 
         entities = []
         for (entity, count) in six.iteritems(entity_counter):
+            entity = entity.encode('utf8', 'xmlcharrefreplace').decode('utf8', 'xmlcharrefreplace')
             if count < min_entity_count:
                 continue
 
             if not disambi and dump_db.is_disambiguation(entity):
                 continue
-
             entities.append(entity)
-
         entity_dict = Trie(entities)
         entity_stats = np.zeros((len(entity_dict), 2), dtype=np.int32)
         for (entity, index) in six.iteritems(entity_dict):
@@ -347,7 +346,6 @@ def _process_page(unicode title, bint lowercase, int32_t min_paragraph_len):
 
     for paragraph in _dump_db.get_paragraphs(title):
         entity_counter.update(link.title for link in paragraph.wiki_links)
-
         tokens = _tokenizer.tokenize(paragraph.text)
         if len(tokens) >= min_paragraph_len:
             if lowercase:

--- a/wikipedia2vec/mention_db.pyx
+++ b/wikipedia2vec/mention_db.pyx
@@ -155,6 +155,7 @@ cdef class MentionDB(object):
                             case_sensitive=case_sensitive)
                 for ret in pool.imap_unordered(f, dump_db.titles(), chunksize=chunk_size):
                     for (text, index) in ret:
+                        text = text.encode('utf8', 'xmlcharrefreplace').decode('utf8', 'xmlcharrefreplace')
                         name_dict[text][index] += 1
                     bar.update(1)
 
@@ -286,6 +287,7 @@ def _count_occurrences(unicode title, int32_t max_mention_len, bint case_sensiti
 
     for paragraph in _dump_db.get_paragraphs(title):
         text = paragraph.text
+        text = text.encode('utf8', 'xmlcharrefreplace').decode('utf8', 'xmlcharrefreplace')
         tokens = _tokenizer.tokenize(text)
 
         if not case_sensitive:


### PR DESCRIPTION
I got UnicodeEncodeError while running the command in Linux.

```
wikipedia2vec build-dump-db zhwiki-latest-pages-articles.xml.bz2 dump.db
wikipedia2vec build-dictionary dump.db dict.db --min-entity-count 0
```

<img width="844" alt="截圖 2022-03-28 上午9 39 09" src="https://user-images.githubusercontent.com/12762532/160321398-75afae47-6dac-4d7a-930a-2bfb5de2c43c.png">

At the end, I solved the error by changing the encoding to allow model apply on chinese wiki dump.
